### PR TITLE
add feature-detection-gated PNG renderer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+#
+# Editor config, for sharing IDE preferences ~ https://editorconfig.org/
+#
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ Returns a *matrix* that can be passed to the `render()` function.
 
 * `options` - the configuration object (optional), depends on the chosen rendering `mode`:
 
-  * `svg` / `svg-uri`: `moduleSize` the unit dimensions of each module, `white` (boolean) output the non-set modules (otherwise will be transparent background), `moduleRound` proportion of how rounded the modules are, `finderRound` to hide the standard finder modules and instead output a shape with the specified roundness, `alignmentRound` to hide the standard alignment modules and instead output a shape with the specified roundness.
+  * `svg` / `svg-uri`: `color` the color of each module (default: 'currentColor'), `moduleSize` the unit dimensions of each module, `white` (boolean) output the non-set modules (otherwise will be transparent background), `moduleRound` proportion of how rounded the modules are, `finderRound` to hide the standard finder modules and instead output a shape with the specified roundness, `alignmentRound` to hide the standard alignment modules and instead output a shape with the specified roundness
 
   * `bmp` / `bmp-uri`: `scale` for the size of a module, `alpha` (boolean) to use a transparent background, `width`/`height` can set a specific image size (rather than scaling the matrix dimensions).
 
+  * `png`: `size` for the width and height of the image, `background` color of the image, `color,moduleRound,finderRound,alignmentRound` from SVG options
+
 Returns the text or binary output from the chosen `mode`.
+
+> **NOTE** png rendering returns a `Promise<Blob>` that needs to be awaited

--- a/qrcode.d.mts
+++ b/qrcode.d.mts
@@ -1,78 +1,87 @@
 export interface GenerateOptions {
   
-  /** 0 to 3 */
-  errorCorrectionLevel?: number
-  
-  /** default true, to maximize the error-correction level within the chosen output size */
-  optimizeEcc?: boolean
-  
-  /** 1 to 40 */
-  minVersion?: number
-  
-  /** 1 to 40 */
-  maxVersion?: number
+    /** 0 to 3 */
+    errorCorrectionLevel?: number
 
-  /** 0 to 7 */
-  maskPattern?: number
+    /** default true, to maximize the error-correction level within the chosen output size */
+    optimizeEcc?: boolean
 
-  /** boolean flag to invert the code, not as widely supported */
-  invert?: boolean
+    /** 1 to 40 */
+    minVersion?: number
 
-  /** the size, in modules, of the quiet area around the code */
-  quiet?: number
+    /** 1 to 40 */
+    maxVersion?: number
+
+    /** 0 to 7 */
+    maskPattern?: number
+
+    /** boolean flag to invert the code, not as widely supported */
+    invert?: boolean
+
+    /** the size, in modules, of the quiet area around the code */
+    quiet?: number
 }
 
 export type RenderMode = 'large' | 'medium' | 'compact' | 'svg' | 'bmp' | 'svg-uri' | 'bmp-uri' | 'sixel'
 
-export type RenderOptions = SvgRenderOptions | BmpRenderOptions | SixelRenderOptions
+export type RenderOptions = SvgRenderOptions | BmpRenderOptions | SixelRenderOptions | PngRenderOptions
 
 export interface SvgRenderOptions {
-  /** (svg / svg-uri only) the color of each module (default: 'currentColor') */
-  color?: string
-  
-  /** (svg / svg-uri only) the unit dimensions of each module */
-  moduleSize?: number
-  
-  /** (svg / svg-uri only) output the non-set modules (otherwise will be transparent background) */
-  white?: boolean
+    /** (svg / svg-uri / png) the CSS color of each module (default: 'currentColor') */
+    color?: string
 
-  /** (svg / svg-uri only) proportion of how rounded the modules are */
-  moduleRound?: number
+    /** (svg / svg-uri) the unit dimensions of each module */
+    moduleSize?: number
 
-  /** (svg / svg-uri only) to hide the standard finder modules and instead output a shape with the specified roundness */
-  finderRound?: number
+    /** (svg / svg-uri) output the non-set modules (otherwise will be transparent background) */
+    white?: boolean
 
-  /** (svg / svg-uri only) to hide the standard alignment modules and instead output a shape with the specified roundness */
-  alignmentRound?: number
+    /** (svg / svg-uri / png) proportion of how rounded the modules are */
+    moduleRound?: number
+
+    /** (svg / svg-uri / png) to hide the standard finder modules and instead output a shape with the specified roundness */
+    finderRound?: number
+
+    /** (svg / svg-uri / png) to hide the standard alignment modules and instead output a shape with the specified roundness */
+    alignmentRound?: number
 }
 
 export interface BmpRenderOptions {
-  /** (bmp / bmp-uri only) for the size of a module */
-  scale?: number
-  
-  /** (bmp / bmp-uri only) to use a transparent background */
-  alpha?: boolean
-  
-  /** (bmp / bmp-uri only) can set a specific image size (rather than scaling the matrix dimensions) */
-  width?: boolean
-  
-  /** (bmp / bmp-uri only) can set a specific image size (rather than scaling the matrix dimensions) */
-  height?: boolean
+    /** (bmp / bmp-uri) for the size of a module */
+    scale?: number
+
+    /** (bmp / bmp-uri) to use a transparent background */
+    alpha?: boolean
+
+    /** (bmp / bmp-uri) can set a specific image size (rather than scaling the matrix dimensions) */
+    width?: boolean
+
+    /** (bmp / bmp-uri) can set a specific image size (rather than scaling the matrix dimensions) */
+    height?: boolean
 }
 
 export interface SixelRenderOptions {
-  /** (sixel) for the size of a module */
-  scale?: number
+    /** (sixel) for the size of a module */
+    scale?: number
+}
+
+export interface PngRenderOptions extends SvgRenderOptions {
+    /** (png) the width and height of the generated image */
+    size: number
+
+    /** (png) the CSS color to draw behind the code  */
+    background: string
 }
 
 export class Matrix {}
 
 export default class QrCode {
-  static generate(data: string, options?: GenerateOptions): Matrix
-  
-  static render(mode: 'large' | 'medium' | 'compact', matrix: Matrix, options?: RenderOptions): string
-  static render(mode: 'svg' | 'svg-uri', matrix: Matrix, options?: SvgRenderOptions): string
-  static render(mode: 'bmp', matrix: Matrix, options?: BmpRenderOptions): Uint8Array
-  static render(mode: 'bmp-uri', matrix: Matrix, options?: BmpRenderOptions): string
-  static render(mode: 'sixel', matrix: Matrix, options?: SixelRenderOptions): string
+    static generate(data: string, options?: GenerateOptions): Matrix
+
+    static render(mode: 'large' | 'medium' | 'compact', matrix: Matrix, options?: RenderOptions): string
+    static render(mode: 'svg' | 'svg-uri', matrix: Matrix, options?: SvgRenderOptions): string
+    static render(mode: 'bmp', matrix: Matrix, options?: BmpRenderOptions): Uint8Array
+    static render(mode: 'bmp-uri', matrix: Matrix, options?: BmpRenderOptions): string
+    static render(mode: 'sixel', matrix: Matrix, options?: SixelRenderOptions): string
+    static render(mode: 'png', matrix: Matrix, options?: PngRenderOptions): Promise<Blob>
 }


### PR DESCRIPTION
- adds "png" render mode that uses `Image` + `OffscreenCanvas` to generate a PNG blob
- it is feature-gated so is only available if the appropriate APIs are also available
- also added an `.editoconfig` to keep formatting consistent